### PR TITLE
fix: グラフ検索時のノード・エッジフィルタリング機能を修正

### DIFF
--- a/src/components/NetworkGraph/computeGraphState.ts
+++ b/src/components/NetworkGraph/computeGraphState.ts
@@ -154,14 +154,14 @@ export function computeGraphState(
 
     // 表示状態の決定
     let hidden = false;
-    let opacity = 1;
+    const opacity = 1;
     let size = 15;
     let borderWidth = MY_POOL.includes(node.id) ? 3 : 2;
-    let color = {
+    const color = {
       background: ROLE_COLORS[node.role] || "#999",
       border: MY_POOL.includes(node.id) ? "#FFD700" : "#333",
     };
-    let font = {
+    const font = {
       color: "#000",
       size: 11,
       bold: MY_POOL.includes(node.id) ? "bold" : undefined,
@@ -196,21 +196,8 @@ export function computeGraphState(
         // 接続ノードは通常表示
         // デフォルト値のまま
       } else {
-        // その他は薄く表示
-        opacity = 0.1;
-        color = {
-          background: `${ROLE_COLORS[node.role] || "#999"}15`,
-          border: "#33333315",
-        };
-        borderWidth = 1;
-        font = {
-          color: "#00000015",
-          size: 11,
-          bold: undefined,
-          strokeWidth: 1,
-          strokeColor: "#ffffff15",
-          vadjust: -20,
-        };
+        // マッチしていないし、接続もされていないノードは完全に非表示
+        hidden = true;
       }
     }
 

--- a/src/components/NetworkGraph/computeGraphStateOptimized.test.ts
+++ b/src/components/NetworkGraph/computeGraphStateOptimized.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { PokemonData, Role } from "../../types";
+import { GraphStateComputer } from "./computeGraphStateOptimized";
+
+describe("GraphStateComputer", () => {
+  let mockData: PokemonData;
+  let computer: GraphStateComputer;
+
+  beforeEach(() => {
+    // テスト用のモックデータ
+    mockData = {
+      nodes: [
+        { id: "miraidon", label: "ミライドン", role: "アサシン" as Role },
+        { id: "pikachu", label: "ピカチュウ", role: "メイジ" as Role },
+        { id: "charizard", label: "リザードン", role: "ファイター" as Role },
+        { id: "blastoise", label: "カメックス", role: "タンク" as Role },
+        { id: "venusaur", label: "フシギバナ", role: "メイジ" as Role },
+        { id: "snorlax", label: "カビゴン", role: "タンク" as Role },
+      ],
+      edges: [
+        // ミライドンの関係
+        { from: "miraidon", to: "pikachu", type: "advantage" },
+        { from: "miraidon", to: "charizard", type: "disadvantage" },
+        // ピカチュウの関係
+        { from: "pikachu", to: "blastoise", type: "disadvantage" },
+        // リザードンの関係
+        { from: "charizard", to: "venusaur", type: "advantage" },
+        // 孤立したエッジ（ミライドンと関係ない）
+        { from: "blastoise", to: "snorlax", type: "advantage" },
+      ],
+    };
+    
+    computer = new GraphStateComputer(mockData);
+  });
+
+  describe("検索なしの場合", () => {
+    it("すべてのノードが表示される", () => {
+      const result = computer.compute({
+        searchTerms: [],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // すべてのノードが表示される（hidden = false）
+      expect(result.nodes).toHaveLength(6);
+      result.nodes.forEach(node => {
+        expect(node.hidden).toBe(false);
+      });
+    });
+
+    it("すべてのエッジが表示される", () => {
+      const result = computer.compute({
+        searchTerms: [],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // すべてのエッジが表示される（hidden = false）
+      expect(result.edges).toHaveLength(5);
+      result.edges.forEach(edge => {
+        expect(edge.hidden).toBe(false);
+      });
+    });
+  });
+
+  describe("検索ありの場合（ミライドン）", () => {
+    it("マッチしたノードと関連ノードのみが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["ミライドン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // ノードの表示状態を確認
+      const nodeMap = new Map(result.nodes.map(n => [n.id, n]));
+      
+      // ミライドン：強調表示
+      expect(nodeMap.get("miraidon")!.hidden).toBe(false);
+      expect(nodeMap.get("miraidon")!.size).toBe(20);
+      expect(nodeMap.get("miraidon")!.borderWidth).toBe(4);
+      
+      // 直接接続ノード：通常表示
+      expect(nodeMap.get("pikachu")!.hidden).toBe(false);
+      expect(nodeMap.get("charizard")!.hidden).toBe(false);
+      
+      // 二次接続ノード（showDirectConnectionsOnly = false なので表示）
+      expect(nodeMap.get("blastoise")!.hidden).toBe(false); // ピカチュウから接続
+      expect(nodeMap.get("venusaur")!.hidden).toBe(false); // リザードンから接続
+      
+      // 関係のないノード：非表示
+      expect(nodeMap.get("snorlax")!.hidden).toBe(true);
+    });
+
+    it("関連エッジのみが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["ミライドン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // エッジの表示状態を確認
+      const edgeMap = new Map(result.edges.map(e => [e.id, e]));
+      
+      // ミライドンに直接つながるエッジ：表示
+      expect(edgeMap.get("miraidon-pikachu-advantage")!.hidden).toBe(false);
+      expect(edgeMap.get("miraidon-charizard-disadvantage")!.hidden).toBe(false);
+      
+      // 一次接続ノード間のエッジ：表示
+      expect(edgeMap.get("pikachu-blastoise-disadvantage")!.hidden).toBe(false);
+      expect(edgeMap.get("charizard-venusaur-advantage")!.hidden).toBe(false);
+      
+      // 関係のないエッジ：非表示
+      expect(edgeMap.get("blastoise-snorlax-advantage")!.hidden).toBe(true);
+    });
+  });
+
+  describe("直接接続のみモード", () => {
+    it("一次接続ノードのみが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["ミライドン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: true,
+        isInitialRender: false,
+      });
+
+      const nodeMap = new Map(result.nodes.map(n => [n.id, n]));
+      
+      // ミライドン：表示
+      expect(nodeMap.get("miraidon")!.hidden).toBe(false);
+      
+      // 直接接続ノード：表示
+      expect(nodeMap.get("pikachu")!.hidden).toBe(false);
+      expect(nodeMap.get("charizard")!.hidden).toBe(false);
+      
+      // 二次接続ノード：非表示
+      expect(nodeMap.get("blastoise")!.hidden).toBe(true);
+      expect(nodeMap.get("venusaur")!.hidden).toBe(true);
+      expect(nodeMap.get("snorlax")!.hidden).toBe(true);
+    });
+
+    it("一次接続エッジのみが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["ミライドン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: true,
+        isInitialRender: false,
+      });
+
+      const edgeMap = new Map(result.edges.map(e => [e.id, e]));
+      
+      // 直接エッジ：表示
+      expect(edgeMap.get("miraidon-pikachu-advantage")!.hidden).toBe(false);
+      expect(edgeMap.get("miraidon-charizard-disadvantage")!.hidden).toBe(false);
+      
+      // 二次エッジ：非表示
+      expect(edgeMap.get("pikachu-blastoise-disadvantage")!.hidden).toBe(true);
+      expect(edgeMap.get("charizard-venusaur-advantage")!.hidden).toBe(true);
+      expect(edgeMap.get("blastoise-snorlax-advantage")!.hidden).toBe(true);
+    });
+  });
+
+  describe("検索結果が0件の場合", () => {
+    it("すべてのノードが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["存在しないポケモン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // すべてのノードが表示される
+      result.nodes.forEach(node => {
+        expect(node.hidden).toBe(false);
+      });
+    });
+
+    it("すべてのエッジが表示される", () => {
+      const result = computer.compute({
+        searchTerms: ["存在しないポケモン"],
+        edgeFilter: "all",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      // すべてのエッジが表示される
+      result.edges.forEach(edge => {
+        expect(edge.hidden).toBe(false);
+      });
+    });
+  });
+
+  describe("エッジフィルタ", () => {
+    it("advantageフィルタで有利エッジのみ表示", () => {
+      const result = computer.compute({
+        searchTerms: [],
+        edgeFilter: "advantage",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      const edgeMap = new Map(mockData.edges.map(e => [`${e.from}-${e.to}-${e.type}`, e]));
+      
+      result.edges.forEach(edge => {
+        const originalEdge = edgeMap.get(edge.id);
+        if (originalEdge?.type === "advantage") {
+          expect(edge.hidden).toBe(false);
+        } else if (originalEdge?.type === "disadvantage") {
+          expect(edge.hidden).toBe(true);
+        }
+      });
+    });
+
+    it("disadvantageフィルタで不利エッジのみ表示", () => {
+      const result = computer.compute({
+        searchTerms: [],
+        edgeFilter: "disadvantage",
+        roleFilter: [],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      const edgeMap = new Map(mockData.edges.map(e => [`${e.from}-${e.to}-${e.type}`, e]));
+      
+      result.edges.forEach(edge => {
+        const originalEdge = edgeMap.get(edge.id);
+        if (originalEdge?.type === "disadvantage") {
+          expect(edge.hidden).toBe(false);
+        } else if (originalEdge?.type === "advantage") {
+          expect(edge.hidden).toBe(true);
+        }
+      });
+    });
+  });
+
+  describe("ロールフィルタ", () => {
+    it("特定ロールのノードのみ表示", () => {
+      const result = computer.compute({
+        searchTerms: [],
+        edgeFilter: "all",
+        roleFilter: ["アサシン", "メイジ"],
+        showDirectConnectionsOnly: false,
+        isInitialRender: false,
+      });
+
+      const nodeMap = new Map(result.nodes.map(n => [n.id, n]));
+      
+      // フィルタに含まれるロール：表示
+      expect(nodeMap.get("miraidon")!.hidden).toBe(false); // アサシン
+      expect(nodeMap.get("pikachu")!.hidden).toBe(false); // メイジ
+      expect(nodeMap.get("venusaur")!.hidden).toBe(false); // メイジ
+      
+      // フィルタに含まれないロール：非表示
+      expect(nodeMap.get("charizard")!.hidden).toBe(true); // ファイター
+      expect(nodeMap.get("blastoise")!.hidden).toBe(true); // タンク
+      expect(nodeMap.get("snorlax")!.hidden).toBe(true); // タンク
+    });
+  });
+});

--- a/src/components/NetworkGraph/computeGraphStateOptimized.ts
+++ b/src/components/NetworkGraph/computeGraphStateOptimized.ts
@@ -1,0 +1,386 @@
+import type { PokemonData, Role } from "../../types";
+import type { GraphState, NodeState, EdgeState } from "./types";
+import { ROLE_COLORS, EDGE_COLORS, MY_POOL } from "./constants";
+
+interface ComputeOptions {
+  searchTerms: string[];
+  edgeFilter: "all" | "advantage" | "disadvantage";
+  roleFilter: Role[];
+  showDirectConnectionsOnly: boolean;
+  isInitialRender?: boolean;
+}
+
+interface NodeIndex {
+  id: string;
+  role: Role;
+  label: string;
+}
+
+interface EdgeIndex {
+  from: string;
+  to: string;
+  type: "advantage" | "disadvantage";
+}
+
+export class GraphStateComputer {
+  private nodeIndex: Map<string, NodeIndex>;
+  private edgesByNode: Map<string, Set<string>>;
+  private edgeIndex: Map<string, EdgeIndex>;
+  private myPoolSet: Set<string>;
+
+  constructor(data: PokemonData) {
+    this.nodeIndex = new Map(
+      data.nodes.map((n) => [n.id, { id: n.id, role: n.role, label: n.label }]),
+    );
+
+    this.edgeIndex = new Map();
+    this.edgesByNode = new Map();
+    this.myPoolSet = new Set(MY_POOL);
+
+    // エッジインデックスの構築
+    for (const edge of data.edges) {
+      const edgeId = `${edge.from}-${edge.to}-${edge.type}`;
+      this.edgeIndex.set(edgeId, edge);
+
+      // ノード別のエッジリストを構築
+      if (!this.edgesByNode.has(edge.from)) {
+        this.edgesByNode.set(edge.from, new Set());
+      }
+      if (!this.edgesByNode.has(edge.to)) {
+        this.edgesByNode.set(edge.to, new Set());
+      }
+      this.edgesByNode.get(edge.from)?.add(edgeId);
+      this.edgesByNode.get(edge.to)?.add(edgeId);
+    }
+  }
+
+  compute(options: ComputeOptions): GraphState {
+    const {
+      searchTerms,
+      edgeFilter,
+      roleFilter,
+      showDirectConnectionsOnly,
+      isInitialRender = false,
+    } = options;
+
+    // 高速化: 検索マッチングの最適化
+    const matchingNodeIds = this.findMatchingNodes(searchTerms);
+    const hasSearch = searchTerms.length > 0;
+    const noSearchResults = hasSearch && matchingNodeIds.size === 0;
+
+    // 高速化: 接続ノードの探索を最適化
+    const { connectedNodeIds, connectedEdgeIds } = this.findConnectedNodes(
+      matchingNodeIds,
+      hasSearch,
+      noSearchResults,
+      showDirectConnectionsOnly,
+    );
+
+    // ロールフィルタの事前計算
+    const roleFilterSet = new Set(roleFilter);
+    const isRoleFilterActive = roleFilter.length > 0 && roleFilter.length < 5;
+
+    // ノード状態の計算
+    const nodes = this.computeNodeStates(
+      matchingNodeIds,
+      connectedNodeIds,
+      roleFilterSet,
+      isRoleFilterActive,
+      hasSearch,
+      noSearchResults,
+      isInitialRender,
+    );
+
+    // エッジ状態の計算
+    const edges = this.computeEdgeStates(
+      connectedEdgeIds,
+      roleFilterSet,
+      isRoleFilterActive,
+      edgeFilter,
+      hasSearch,
+      noSearchResults,
+    );
+
+    return { nodes, edges };
+  }
+
+  private findMatchingNodes(searchTerms: string[]): Set<string> {
+    if (searchTerms.length === 0) return new Set();
+
+    const matching = new Set<string>();
+    const lowerSearchTerms = searchTerms.map((t) => t.toLowerCase());
+
+    for (const [id, node] of this.nodeIndex) {
+      const labelLower = node.label.toLowerCase();
+      const idLower = id.toLowerCase();
+
+      for (const term of lowerSearchTerms) {
+        if (labelLower.includes(term) || idLower.includes(term)) {
+          matching.add(id);
+          break;
+        }
+      }
+    }
+
+    return matching;
+  }
+
+  private findConnectedNodes(
+    matchingNodeIds: Set<string>,
+    hasSearch: boolean,
+    noSearchResults: boolean,
+    showDirectConnectionsOnly: boolean,
+  ): { connectedNodeIds: Set<string>; connectedEdgeIds: Set<string> } {
+    if (!hasSearch || noSearchResults) {
+      return { connectedNodeIds: new Set(), connectedEdgeIds: new Set() };
+    }
+
+    const connectedNodeIds = new Set<string>();
+    const connectedEdgeIds = new Set<string>();
+
+    // 直接接続の高速検索
+    for (const nodeId of matchingNodeIds) {
+      const edges = this.edgesByNode.get(nodeId);
+      if (!edges) continue;
+
+      for (const edgeId of edges) {
+        const edge = this.edgeIndex.get(edgeId);
+        if (!edge) continue;
+        
+        // マッチしたノードから直接つながるエッジを追加
+        connectedEdgeIds.add(edgeId);
+
+        // 接続先のノードを追加
+        if (edge.from === nodeId) {
+          connectedNodeIds.add(edge.to);
+        } else {
+          connectedNodeIds.add(edge.from);
+        }
+      }
+    }
+
+    // 二次接続（直接接続のみモードでない場合）
+    if (!showDirectConnectionsOnly) {
+      // 一次接続ノードのコピーを作成してイテレート（元のSetへの追加を避ける）
+      const firstLevelConnected = new Set(connectedNodeIds);
+      
+      // 二次接続ノードとエッジの収集
+      for (const nodeId of firstLevelConnected) {
+        // マッチしたノード自身はスキップ
+        if (matchingNodeIds.has(nodeId)) continue;
+
+        const edges = this.edgesByNode.get(nodeId);
+        if (!edges) continue;
+
+        for (const edgeId of edges) {
+          const edge = this.edgeIndex.get(edgeId);
+          if (!edge) continue;
+          
+          const otherNode = edge.from === nodeId ? edge.to : edge.from;
+
+          // まだ含まれていないノードを二次接続として追加
+          if (!matchingNodeIds.has(otherNode) && !firstLevelConnected.has(otherNode)) {
+            connectedNodeIds.add(otherNode);
+            connectedEdgeIds.add(edgeId);
+          }
+        }
+      }
+      
+      // 表示されるノード間のエッジをすべて収集
+      const visibleNodes = new Set([...matchingNodeIds, ...connectedNodeIds]);
+      for (const [edgeId, edge] of this.edgeIndex) {
+        // すでに追加済みのエッジはスキップ
+        if (connectedEdgeIds.has(edgeId)) continue;
+        
+        // 両端が表示ノードに含まれるエッジを追加
+        if (visibleNodes.has(edge.from) && visibleNodes.has(edge.to)) {
+          connectedEdgeIds.add(edgeId);
+        }
+      }
+    }
+
+    return { connectedNodeIds, connectedEdgeIds };
+  }
+
+  private computeNodeStates(
+    matchingNodeIds: Set<string>,
+    connectedNodeIds: Set<string>,
+    roleFilterSet: Set<Role>,
+    isRoleFilterActive: boolean,
+    hasSearch: boolean,
+    noSearchResults: boolean,
+    isInitialRender: boolean,
+  ): NodeState[] {
+    const nodes: NodeState[] = [];
+    let index = 0;
+    const gridSize = Math.ceil(Math.sqrt(this.nodeIndex.size));
+    const spacing = 300;
+    const jitter = 100;
+
+    for (const [id, node] of this.nodeIndex) {
+      const isMatching = matchingNodeIds.has(id);
+      const isConnected = connectedNodeIds.has(id);
+      const isRoleFiltered =
+        isRoleFilterActive && !roleFilterSet.has(node.role);
+      const isMyPool = this.myPoolSet.has(id);
+
+      // デフォルト値
+      let hidden = false;
+      const opacity = 1;
+      let size = 15;
+      let borderWidth = isMyPool ? 3 : 2;
+      const color = {
+        background: ROLE_COLORS[node.role] || "#999",
+        border: isMyPool ? "#FFD700" : "#333",
+      };
+      const font = {
+        color: "#000",
+        size: 11,
+        bold: isMyPool ? "bold" : undefined,
+        strokeWidth: 2,
+        strokeColor: "#fff",
+        vadjust: -20,
+      };
+
+      // 表示状態の決定（簡略化）
+      if (!hasSearch) {
+        hidden = isRoleFiltered;
+      } else if (!noSearchResults) {
+        if (isRoleFiltered) {
+          hidden = true;
+        } else if (isMatching) {
+          size = 20;
+          borderWidth = 4;
+          color.border = "#FFD700";
+          font.size = 12;
+          font.bold = "bold";
+        } else if (isConnected) {
+          // 接続ノードは通常表示
+          // デフォルト値のまま
+        } else {
+          // マッチしていないし、接続もされていないノードは完全に非表示
+          hidden = true;
+        }
+      }
+
+      const row = Math.floor(index / gridSize);
+      const col = index % gridSize;
+
+      nodes.push({
+        id,
+        label: node.label,
+        hidden,
+        opacity,
+        size,
+        color,
+        borderWidth,
+        font: {
+          ...font,
+          bold: font.bold || undefined,
+        },
+        ...(isInitialRender
+          ? {}
+          : {
+              x:
+                col * spacing -
+                (gridSize * spacing) / 2 +
+                (Math.random() - 0.5) * jitter,
+              y:
+                row * spacing -
+                (gridSize * spacing) / 2 +
+                (Math.random() - 0.5) * jitter,
+            }),
+      });
+
+      index++;
+    }
+
+    return nodes;
+  }
+
+  private computeEdgeStates(
+    connectedEdgeIds: Set<string>,
+    roleFilterSet: Set<Role>,
+    isRoleFilterActive: boolean,
+    edgeFilter: "all" | "advantage" | "disadvantage",
+    hasSearch: boolean,
+    noSearchResults: boolean,
+  ): EdgeState[] {
+    const edges: EdgeState[] = [];
+
+    for (const [edgeId, edge] of this.edgeIndex) {
+      const fromNode = this.nodeIndex.get(edge.from);
+      const toNode = this.nodeIndex.get(edge.to);
+
+      const isEdgeTypeFiltered =
+        edgeFilter !== "all" && edge.type !== edgeFilter;
+      const isRoleFiltered =
+        isRoleFilterActive &&
+        ((fromNode && !roleFilterSet.has(fromNode.role)) ||
+          (toNode && !roleFilterSet.has(toNode.role)));
+
+      const isConnected =
+        !hasSearch || noSearchResults || connectedEdgeIds.has(edgeId);
+
+      let hidden = isEdgeTypeFiltered;
+      const opacity = 1;
+      const width = 1.5;
+      const arrowScale = 0.8;
+      const color: string = EDGE_COLORS[edge.type];
+
+      if (!hasSearch) {
+        // 検索がない場合は、エッジタイプとロールフィルタのみ適用
+        hidden = Boolean(hidden || isRoleFiltered);
+      } else if (!noSearchResults) {
+        // 検索があり結果がある場合
+        if (isRoleFiltered) {
+          hidden = true;
+        } else if (!isConnected) {
+          // 接続されていないエッジは完全に非表示にする
+          hidden = true;
+        }
+      }
+      // noSearchResults の場合（検索結果が0件）は、
+      // すべてのエッジを通常表示（エッジタイプフィルタのみ適用）
+
+      edges.push({
+        id: edgeId,
+        from: edge.from,
+        to: edge.to,
+        hidden,
+        color: {
+          color,
+          opacity,
+        },
+        width,
+        arrows: {
+          to: {
+            enabled: true,
+            scaleFactor: arrowScale,
+          },
+        },
+      });
+    }
+
+    return edges;
+  }
+}
+
+// 互換性のための関数エクスポート
+export function computeGraphState(
+  data: PokemonData,
+  searchTerms: string[],
+  edgeFilter: "all" | "advantage" | "disadvantage",
+  roleFilter: Role[],
+  showDirectConnectionsOnly: boolean,
+  isInitialRender = false,
+): GraphState {
+  const computer = new GraphStateComputer(data);
+  return computer.compute({
+    searchTerms,
+    edgeFilter,
+    roleFilter,
+    showDirectConnectionsOnly,
+    isInitialRender,
+  });
+}

--- a/src/components/NetworkGraph/constants.ts
+++ b/src/components/NetworkGraph/constants.ts
@@ -98,3 +98,18 @@ export const ISOLATED_NODES_CONFIG = {
   radius: 500, // 孤立ノードを配置する円の半径
   disablePhysics: true, // 孤立ノードの物理シミュレーション無効化
 } as const;
+
+export const ROLE_COLORS: Record<string, string> = {
+  タンク: "#4ECDC4",
+  サポート: "#F4D03F",
+  メイジ: "#FF6B6B",
+  アサシン: "#9B59B6",
+  ファイター: "#45B7D1",
+};
+
+export const EDGE_COLORS = {
+  advantage: "#4CAF50",
+  disadvantage: "#F44336",
+} as const;
+
+export const MY_POOL: string[] = [];

--- a/src/components/NetworkGraph/hooks/useDifferentialUpdate.ts
+++ b/src/components/NetworkGraph/hooks/useDifferentialUpdate.ts
@@ -1,0 +1,165 @@
+import { useRef, useCallback } from "react";
+import type { DataSet } from "vis-data";
+import type { Node, Edge } from "vis-network";
+import type { NodeState, EdgeState } from "../types";
+
+interface DiffResult<T> {
+  added: T[];
+  removed: string[];
+  updated: T[];
+}
+
+export function useDifferentialUpdate() {
+  const prevNodesRef = useRef<Map<string, NodeState>>(new Map());
+  const prevEdgesRef = useRef<Map<string, EdgeState>>(new Map());
+
+  const diffNodes = useCallback(
+    (newNodes: NodeState[]): DiffResult<NodeState> => {
+      const prevNodes = prevNodesRef.current;
+      const newNodeMap = new Map(newNodes.map((n) => [n.id, n]));
+
+      const added: NodeState[] = [];
+      const removed: string[] = [];
+      const updated: NodeState[] = [];
+
+      // 新規・更新ノードの検出
+      for (const node of newNodes) {
+        const prevNode = prevNodes.get(node.id);
+        if (!prevNode) {
+          added.push(node);
+        } else if (hasNodeChanged(prevNode, node)) {
+          updated.push(node);
+        }
+      }
+
+      // 削除されたノードの検出
+      for (const [id] of prevNodes) {
+        if (!newNodeMap.has(id)) {
+          removed.push(id);
+        }
+      }
+
+      prevNodesRef.current = newNodeMap;
+      return { added, removed, updated };
+    },
+    [],
+  );
+
+  const diffEdges = useCallback(
+    (newEdges: EdgeState[]): DiffResult<EdgeState> => {
+      const prevEdges = prevEdgesRef.current;
+      const newEdgeMap = new Map(newEdges.map((e) => [e.id, e]));
+
+      const added: EdgeState[] = [];
+      const removed: string[] = [];
+      const updated: EdgeState[] = [];
+
+      // 新規・更新エッジの検出
+      for (const edge of newEdges) {
+        const prevEdge = prevEdges.get(edge.id);
+        if (!prevEdge) {
+          added.push(edge);
+        } else if (hasEdgeChanged(prevEdge, edge)) {
+          updated.push(edge);
+        }
+      }
+
+      // 削除されたエッジの検出
+      for (const [id] of prevEdges) {
+        if (!newEdgeMap.has(id)) {
+          removed.push(id);
+        }
+      }
+
+      prevEdgesRef.current = newEdgeMap;
+      return { added, removed, updated };
+    },
+    [],
+  );
+
+  const applyNodeDiff = useCallback(
+    (
+      dataSet: DataSet<Node>,
+      diff: DiffResult<NodeState>,
+      preservePositions = true,
+    ) => {
+      const operations: Array<() => void> = [];
+
+      if (diff.removed.length > 0) {
+        operations.push(() => dataSet.remove(diff.removed));
+      }
+
+      if (diff.added.length > 0) {
+        operations.push(() => dataSet.add(diff.added));
+      }
+
+      if (diff.updated.length > 0) {
+        const updates = preservePositions
+          ? diff.updated.map(({ x, y, ...node }) => node)
+          : diff.updated;
+        operations.push(() => dataSet.update(updates));
+      }
+
+      // バッチ実行
+      if (operations.length > 0) {
+        operations.forEach((op) => op());
+      }
+
+      return operations.length > 0;
+    },
+    [],
+  );
+
+  const applyEdgeDiff = useCallback(
+    (dataSet: DataSet<Edge>, diff: DiffResult<EdgeState>) => {
+      const operations: Array<() => void> = [];
+
+      if (diff.removed.length > 0) {
+        operations.push(() => dataSet.remove(diff.removed));
+      }
+
+      if (diff.added.length > 0) {
+        operations.push(() => dataSet.add(diff.added));
+      }
+
+      if (diff.updated.length > 0) {
+        operations.push(() => dataSet.update(diff.updated));
+      }
+
+      // バッチ実行
+      if (operations.length > 0) {
+        operations.forEach((op) => op());
+      }
+
+      return operations.length > 0;
+    },
+    [],
+  );
+
+  return {
+    diffNodes,
+    diffEdges,
+    applyNodeDiff,
+    applyEdgeDiff,
+  };
+}
+
+function hasNodeChanged(prev: NodeState, next: NodeState): boolean {
+  return (
+    prev.hidden !== next.hidden ||
+    prev.opacity !== next.opacity ||
+    prev.size !== next.size ||
+    prev.borderWidth !== next.borderWidth ||
+    JSON.stringify(prev.color) !== JSON.stringify(next.color) ||
+    JSON.stringify(prev.font) !== JSON.stringify(next.font)
+  );
+}
+
+function hasEdgeChanged(prev: EdgeState, next: EdgeState): boolean {
+  return (
+    prev.hidden !== next.hidden ||
+    prev.width !== next.width ||
+    JSON.stringify(prev.color) !== JSON.stringify(next.color) ||
+    JSON.stringify(prev.arrows) !== JSON.stringify(next.arrows)
+  );
+}

--- a/src/components/NetworkGraph/hooks/useNetworkInstance.ts
+++ b/src/components/NetworkGraph/hooks/useNetworkInstance.ts
@@ -18,23 +18,61 @@ export function useNetworkInstance(): NetworkInstance {
   const nodesDatasetRef = useRef<DataSet<Node> | null>(null);
   const edgesDatasetRef = useRef<DataSet<Edge> | null>(null);
   const isInitialized = useRef(false);
+  const physicsTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useLayoutEffect(() => {
     if (!containerRef.current) return;
     if (isInitialized.current) return;
 
-    // データセットを作成（初期は空）
-    const nodesDataset = new DataSet<Node>([]);
-    const edgesDataset = new DataSet<Edge>([]);
+    // データセットを作成（初期は空、バッチ更新をサポート）
+    const nodesDataset = new DataSet<Node>([], {
+      queue: { delay: 50, max: 100 }, // バッチ更新の設定
+    });
+    const edgesDataset = new DataSet<Edge>([], {
+      queue: { delay: 50, max: 100 }, // バッチ更新の設定
+    });
 
     nodesDatasetRef.current = nodesDataset;
     edgesDatasetRef.current = edgesDataset;
+
+    // 最適化されたネットワークオプション
+    const optimizedOptions = {
+      ...NETWORK_OPTIONS,
+      physics: {
+        ...NETWORK_OPTIONS.physics,
+        stabilization: {
+          enabled: true,
+          iterations: 50, // 安定化イテレーションを減らす
+          updateInterval: 50,
+          onlyDynamicEdges: false,
+          fit: false,
+        },
+        solver: "forceAtlas2Based",
+        forceAtlas2Based: {
+          theta: 0.5,
+          gravitationalConstant: -50,
+          centralGravity: 0.01,
+          springConstant: 0.08,
+          springLength: 100,
+          damping: 0.4,
+        },
+      },
+      layout: {
+        ...NETWORK_OPTIONS.layout,
+        improvedLayout: false, // 初期レイアウトの計算を高速化
+      },
+      interaction: {
+        ...NETWORK_OPTIONS.interaction,
+        hideEdgesOnDrag: true, // ドラッグ中はエッジを非表示にしてパフォーマンス向上
+        hideEdgesOnZoom: false,
+      },
+    };
 
     // ネットワークを初期化
     const network = new Network(
       containerRef.current,
       { nodes: nodesDataset, edges: edgesDataset },
-      NETWORK_OPTIONS,
+      optimizedOptions,
     );
 
     networkRef.current = network;
@@ -42,26 +80,58 @@ export function useNetworkInstance(): NetworkInstance {
 
     // 安定化後に物理エンジンを停止
     network.on("stabilizationIterationsDone", () => {
-      network.setOptions({ physics: { enabled: false } });
+      if (physicsTimeoutRef.current) {
+        clearTimeout(physicsTimeoutRef.current);
+      }
+      physicsTimeoutRef.current = setTimeout(() => {
+        network.setOptions({ physics: { enabled: false } });
+      }, 100);
     });
 
     // ドラッグ開始時の処理
     network.on("dragStart", (params) => {
       if (params.nodes.length > 0) {
+        // 即座に物理エンジンを無効化
         network.setOptions({
-          physics: {
-            enabled: false,
-          },
+          physics: { enabled: false },
         });
       }
     });
 
     // ドラッグ終了時の処理
     network.on("dragEnd", () => {
+      // 物理エンジンは無効のまま
       network.setOptions({ physics: { enabled: false } });
     });
 
+    // ズーム変更時の最適化
+    let zoomTimeout: NodeJS.Timeout | null = null;
+    network.on("zoom", () => {
+      if (zoomTimeout) clearTimeout(zoomTimeout);
+      zoomTimeout = setTimeout(() => {
+        const scale = network.getScale();
+        // ズームレベルに応じてエッジの表示を調整
+        if (scale < 0.3) {
+          network.setOptions({
+            edges: { smooth: false }, // 低ズーム時は曲線を無効化
+          });
+        } else {
+          network.setOptions({
+            edges: {
+              smooth: { enabled: true, type: "continuous", roundness: 0.5 },
+            },
+          });
+        }
+      }, 100);
+    });
+
     return () => {
+      if (physicsTimeoutRef.current) {
+        clearTimeout(physicsTimeoutRef.current);
+      }
+      if (zoomTimeout) {
+        clearTimeout(zoomTimeout);
+      }
       network.destroy();
       isInitialized.current = false;
     };

--- a/src/components/NetworkGraph/index.tsx
+++ b/src/components/NetworkGraph/index.tsx
@@ -1,9 +1,10 @@
 import type React from "react";
 import { memo, useMemo, useEffect, useRef } from "react";
-import type { NetworkGraphProps } from "./types";
+import type { NetworkGraphProps, NodeState } from "./types";
 import { useNetworkInstance } from "./hooks/useNetworkInstance";
 import { useDebouncedSelection } from "./hooks/useDebouncedSelection";
-import { computeGraphState } from "./computeGraphState";
+import { useDifferentialUpdate } from "./hooks/useDifferentialUpdate";
+import { GraphStateComputer } from "./computeGraphStateOptimized";
 
 const NetworkGraph: React.FC<NetworkGraphProps> = memo(
   ({
@@ -19,23 +20,29 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
     // 初回レンダリングかどうかを追跡
     const isInitialRender = useRef(true);
 
+    // GraphStateComputerのインスタンスをメモ化
+    const graphComputer = useMemo(() => new GraphStateComputer(data), [data]);
+
     // ネットワークインスタンスを初期化（一度だけ）
     const { containerRef, network, nodesDataset, edgesDataset } =
       useNetworkInstance();
 
-    // グラフ状態を純粋関数で計算
+    // 差分更新用のフック
+    const { diffNodes, diffEdges, applyNodeDiff, applyEdgeDiff } =
+      useDifferentialUpdate();
+
+    // グラフ状態を純粋関数で計算（最適化版を使用）
     const graphState = useMemo(
       () =>
-        computeGraphState(
-          data,
-          debouncedSelection,
+        graphComputer.compute({
+          searchTerms: debouncedSelection,
           edgeFilter,
           roleFilter,
           showDirectConnectionsOnly,
-          isInitialRender.current,
-        ),
+          isInitialRender: isInitialRender.current,
+        }),
       [
-        data,
+        graphComputer,
         debouncedSelection,
         edgeFilter,
         roleFilter,
@@ -43,7 +50,7 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
       ],
     );
 
-    // DataSetを更新（ネットワーク初期化後に実行）
+    // DataSetを差分更新（ネットワーク初期化後に実行）
     useEffect(() => {
       // ネットワークとデータセットが初期化されるまで待つ
       if (!nodesDataset.current || !edgesDataset.current || !network.current) {
@@ -56,18 +63,26 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
         edgesDataset.current.add(graphState.edges);
         isInitialRender.current = false;
       } else {
-        // 2回目以降はupdate()を使用して差分更新（位置は更新しない）
-        const nodesWithoutPosition = graphState.nodes.map((node) => {
-          const { x, y, ...nodeWithoutPos } = node;
-          return nodeWithoutPos;
-        });
-        nodesDataset.current.update(nodesWithoutPosition);
-        edgesDataset.current.update(graphState.edges);
-        setTimeout(() => {
-          network.current?.setOptions({
-            physics: { enabled: false },
-          });
-        }, 100);
+        // 2回目以降は差分更新を使用
+        const nodeDiff = diffNodes(graphState.nodes);
+        const edgeDiff = diffEdges(graphState.edges);
+
+        // バッチ更新を有効化
+        const hasNodeChanges = applyNodeDiff(
+          nodesDataset.current,
+          nodeDiff,
+          true,
+        );
+        const hasEdgeChanges = applyEdgeDiff(edgesDataset.current, edgeDiff);
+
+        // 変更があった場合のみ物理エンジンを一時的に無効化
+        if (hasNodeChanges || hasEdgeChanges) {
+          setTimeout(() => {
+            network.current?.setOptions({
+              physics: { enabled: false },
+            });
+          }, 50);
+        }
       }
 
       // 選択状態をリセット
@@ -76,11 +91,11 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
       // 検索でマッチしたノードを選択
       if (debouncedSelection.length > 0) {
         const selectedNodeIds = graphState.nodes
-          .filter((node) => {
+          .filter((node: NodeState) => {
             // マッチしたノードを特定（size が selected のもの）
             return node.size === 20 && node.borderWidth === 4;
           })
-          .map((node) => node.id);
+          .map((node: NodeState) => node.id);
 
         if (selectedNodeIds.length > 0) {
           network.current.selectNodes(selectedNodeIds);
@@ -89,7 +104,7 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
           const prevSelection = network.current.getSelectedNodes();
           const hasChanged =
             selectedNodeIds.length !== prevSelection.length ||
-            !selectedNodeIds.every((id) => prevSelection.includes(id));
+            !selectedNodeIds.every((id: string) => prevSelection.includes(id));
 
           if (hasChanged) {
             setTimeout(() => {
@@ -103,7 +118,17 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
           }
         }
       }
-    }, [graphState, debouncedSelection, network, nodesDataset, edgesDataset]);
+    }, [
+      graphState,
+      debouncedSelection,
+      network,
+      nodesDataset,
+      edgesDataset,
+      diffNodes,
+      diffEdges,
+      applyNodeDiff,
+      applyEdgeDiff,
+    ]);
 
     return (
       <div
@@ -114,6 +139,19 @@ const NetworkGraph: React.FC<NetworkGraphProps> = memo(
           minHeight: "750px",
         }}
       />
+    );
+  },
+  // カスタム比較関数で再レンダリングを最適化
+  (prevProps, nextProps) => {
+    return (
+      prevProps.data === nextProps.data &&
+      prevProps.edgeFilter === nextProps.edgeFilter &&
+      JSON.stringify(prevProps.roleFilter) ===
+        JSON.stringify(nextProps.roleFilter) &&
+      prevProps.showDirectConnectionsOnly ===
+        nextProps.showDirectConnectionsOnly &&
+      JSON.stringify(prevProps.selectedPokemon) ===
+        JSON.stringify(nextProps.selectedPokemon)
     );
   },
 );

--- a/src/components/NetworkGraph/types.ts
+++ b/src/components/NetworkGraph/types.ts
@@ -65,3 +65,49 @@ export interface NetworkRefs {
     import("vis-data").DataSet<EdgeData> | null
   >;
 }
+
+export interface NodeState {
+  id: string;
+  label: string;
+  hidden: boolean;
+  opacity: number;
+  size: number;
+  color: {
+    background: string;
+    border: string;
+  };
+  borderWidth: number;
+  font: {
+    color: string;
+    size: number;
+    bold?: string;
+    strokeWidth: number;
+    strokeColor: string;
+    vadjust: number;
+  };
+  x?: number;
+  y?: number;
+}
+
+export interface EdgeState {
+  id: string;
+  from: string;
+  to: string;
+  hidden: boolean;
+  color: {
+    color: string;
+    opacity: number;
+  };
+  width: number;
+  arrows: {
+    to: {
+      enabled: boolean;
+      scaleFactor: number;
+    };
+  };
+}
+
+export interface GraphState {
+  nodes: NodeState[];
+  edges: EdgeState[];
+}


### PR DESCRIPTION
## 概要
ポケモン検索時に関係のないノード・エッジが表示される問題を修正し、パフォーマンスを大幅に改善しました。

## 修正内容

### 🐛 バグ修正
- 検索時に関係のないノード・エッジが表示されていた問題を修正
- 二次接続処理の無限ループ可能性を解消
- エッジフィルタが正しく動作しない問題を修正

### ⚡ パフォーマンス改善
- **GraphStateComputer**: インデックスベースの高速検索実装
- **差分更新システム**: 変更のあるノード/エッジのみ更新
- **バッチ更新**: vis.jsのDataSet更新を最適化
- **物理エンジン**: 不要なタイミングでの無効化を削減

### 🧪 テスト
- TDD（テスト駆動開発）で実装
- 11個の包括的なテストケースを追加
- 全52テストがパス

## 動作確認
- [x] ポケモン検索時、関連ノード・エッジのみ表示
- [x] フィルター切り替えが高速
- [x] ドラッグ&ドロップがスムーズ
- [x] 既存機能にデグレなし

## スクリーンショット
検索前：全ノード表示
検索後（ミライドン）：関連ノードのみ表示

🤖 Generated with [Claude Code](https://claude.ai/code)